### PR TITLE
Iow 660 refine memory widgets

### DIFF
--- a/cloudwatch_monitoring/lambdas.py
+++ b/cloudwatch_monitoring/lambdas.py
@@ -243,7 +243,7 @@ def create_lambda_widgets(region, deploy_stage):
                 'height': positioning['height'],
                 'width': positioning['width'],
                 "properties": {
-                    "query": f"SOURCE '/aws/lambda/{function_name}' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+                    "query": f"SOURCE '/aws/lambda/{function_name}' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
                     "region": region,
                     "title": f"{widget_title} Memory Usage",
                     "view": "timeSeries",

--- a/cloudwatch_monitoring/tests/test_widgets.py
+++ b/cloudwatch_monitoring/tests/test_widgets.py
@@ -617,8 +617,6 @@ grow_db_memory_usage_widget = {
     }
 }
 
-
-
 misc_function_numeric_stats_widget = {
     'type': 'metric',
     'height': 6,

--- a/cloudwatch_monitoring/tests/test_widgets.py
+++ b/cloudwatch_monitoring/tests/test_widgets.py
@@ -180,7 +180,7 @@ error_handler_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/aqts-capture-error-handler-DEV-aqtsErrorHandler' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/aqts-capture-error-handler-DEV-aqtsErrorHandler' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "Error Handler Memory Usage",
         "view": "timeSeries",
@@ -252,7 +252,7 @@ capture_trigger_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/aqts-capture-trigger-DEV-aqtsCaptureTrigger' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/aqts-capture-trigger-DEV-aqtsCaptureTrigger' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "Capture Trigger Memory Usage",
         "view": "timeSeries",
@@ -324,7 +324,7 @@ dvstat_transform_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/aqts-capture-dvstat-transform-DEV-transform' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/aqts-capture-dvstat-transform-DEV-transform' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "DV stat Transformer Memory Usage",
         "view": "timeSeries",
@@ -396,7 +396,7 @@ field_visit_transform_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/aqts-capture-field-visit-transform-DEV-transform' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/aqts-capture-field-visit-transform-DEV-transform' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "Field visit transformer Memory Usage",
         "view": "timeSeries",
@@ -467,7 +467,7 @@ rdb_loader_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/etl-discrete-groundwater-rdb-DEV-loadRdb' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/etl-discrete-groundwater-rdb-DEV-loadRdb' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "Load RDB Files Memory Usage",
         "view": "timeSeries",
@@ -538,7 +538,7 @@ pruner_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/aqts-capture-pruner-DEV-pruneTimeSeries' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/aqts-capture-pruner-DEV-pruneTimeSeries' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "Prune Old Data Memory Usage",
         "view": "timeSeries",
@@ -609,13 +609,15 @@ grow_db_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/aqts-capture-ecosystem-switch-DEV-growDb' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/aqts-capture-ecosystem-switch-DEV-growDb' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "Grow DB Memory Usage",
         "view": "timeSeries",
         "stacked": False
     }
 }
+
+
 
 misc_function_numeric_stats_widget = {
     'type': 'metric',
@@ -681,7 +683,7 @@ misc_function_memory_usage_widget = {
     'height': 6,
     'width': 6,
     "properties": {
-        "query": f"SOURCE '/aws/lambda/function_DEV_name_not_added_to_lookups_yet' | filter @type=\"REPORT\" | avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
+        "query": f"SOURCE '/aws/lambda/function_DEV_name_not_added_to_lookups_yet' | filter @type=\"REPORT\" | max(@memorySize) as allocatedMemory, avg(@maxMemoryUsed) as mean_MemoryUsed, max(@maxMemoryUsed) as max_MemoryUsed by bin(5min)",
         "region": 'us-south-10',
         "title": "function_DEV_name_not_added_to_lookups_yet Memory Usage",
         "view": "timeSeries",


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
https://internal.cida.usgs.gov/jira/browse/IOW-660

Description
-----------
* Added total allocated memory line to the memory usage widgets.  Not as cool as an annotation, which are not currently supported with log type widgets, but still workable.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
